### PR TITLE
Fix: Scroll-to-top bug on Privacy and Terms pages

### DIFF
--- a/src/views/Privacy.jsx
+++ b/src/views/Privacy.jsx
@@ -1,13 +1,14 @@
 import PrivacyPolicy from "../components/PrivacyTermsUnsubscribe/PrivacyPolicy";
 import PageHero from "../components/ReusableComponents/HeroComponent/Hero";
-
+import useScrollToTop from "../customHooks/useScrollToTop";
 
 export default function Privacy() {
+  useScrollToTop();
 
-    return(
-        <main>
-            <PageHero Title1="Privacy Policy"/>
-            <PrivacyPolicy />
-        </main>
-    )
+  return (
+    <main>
+      <PageHero Title1="Privacy Policy" />
+      <PrivacyPolicy />
+    </main>
+  );
 }

--- a/src/views/Terms.jsx
+++ b/src/views/Terms.jsx
@@ -1,13 +1,14 @@
 import PageHero from "../components/ReusableComponents/HeroComponent/Hero";
 import TermsAndConditions from "../components/PrivacyTermsUnsubscribe/TermsAndConditions";
-
+import useScrollToTop from "../customHooks/useScrollToTop";
 
 export default function Terms() {
+  useScrollToTop();
 
-    return(
-        <main> 
-        <PageHero Title1="Terms and Conditions" />
-        <TermsAndConditions />
-        </main>
-    )
+  return (
+    <main>
+      <PageHero Title1="Terms and Conditions" />
+      <TermsAndConditions />
+    </main>
+  );
 }


### PR DESCRIPTION
Fixed issue where Privacy Policy and Terms & Conditions pages were not resetting scroll position when navigated to from the footer.

- Added useScrollToTop() hook to both components.
- Verified locally — pages now load correctly at top.
